### PR TITLE
tokyu10 用の記述に変更する

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <link href="./stylesheets/font-awesome.min.css" media="screen" rel="stylesheet" type="text/css" />
 <link href="./stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />
 <link href="./stylesheets/regional.css" media="screen" rel="stylesheet" type="text/css" />
-<title>TokyuRuby会議09 - Regional RubyKaigi</title>
+<title>TokyuRuby会議10 - Regional RubyKaigi</title>
 </head>
 <body>
 <div style='background: #000'>
@@ -18,12 +18,12 @@
   <div id='container'>
     <div class='event'>
       <h2>
-        TokyuRuby会議09<span class='official_tag'>
+        TokyuRuby会議10<span class='official_tag'>
           <br />(
-          tokyurubykaigi09
+          tokyurubykaigi10
           <span class='official_tag'>
             ,
-            <a href="http://twitter.com/search?q=%23tqrk09">#tqrk09</a>
+            <a href="http://twitter.com/search?q=%23tqrk10">#tqrk10</a>
           </span>
           )
         </span>
@@ -31,11 +31,11 @@
     </div>
     <h3>LT への応募</h3>
     <div class="registration_external">
-        LTの募集は終了しました。
+        LTの募集は4/1頃に開始予定です。募集開始まで今少しお待ち下さい。
     </div>
     <hr>
     <h3>参加登録</h3>
-    <div class="registration_external">一般参加登録は<a href="https://tokyu-rubykaigi.doorkeeper.jp/events/29403">こちら</a></div>
+    <div class="registration_external">一般参加登録の受付は5月上旬を予定しています。</div>
     <div class='event_desc'><hr>
       <h3>TokyuRuby会議について</h3>
       <ul>
@@ -43,12 +43,8 @@
         <li>Ruby に興味を持つエンジニアが集う <a href="https://www.facebook.com/groups/928069233888488/">Tokyu.rb</a> 主催の LT 大会です。</li>
         <li>飲み食いしつつ、みんなで LT をして盛り上がろうというイベントです。</li>
         <li><strong>抽選LT があります！</strong> 抽選LT発表者の指名は抽選により、当日会場にて行います！当たるかもしれません！</li>
-        <li>今回も参加者のみなさんの投票により<strong>飯王、LT王</strong>を決定します！
-          <ul><li>投票にはGitHubアカウントが必要となります。</li></ul>
-          <ul><li>今回は酒王の表彰はありません。</li></ul>
-          <ul><li>LT王、飯王を目指す皆様、エントリーにはGitHubアカウントが必要となります。</li></ul>
-          <ul><li><a href="https://docs.google.com/presentation/d/1Y4z8oADpZfX_eg2pOaq6f5xqyNk8LydciPbrE0asoOE/pub?start=false&loop=false&delayms=3000">飯王の集計ルールについてのお知らせ</a></li></ul></li>
-          <ul><li><span class="fa-2x"><a href="https://elt-tqrk09.herokuapp.com/" ><i class="fa fa-beer" style="color:#FFD700;" ></i><span class="fa-border" >LT王、飯王への投票所</span><i class="fa fa-cutlery" style="color:#A9A9A9;" ></i></a></span><br ><span style="color:#FF0000;">(現在、GitHubにログインした状態だと投票アプリへのログインが出来ないので、一度GitHubからログアウトしてからお試しください。)</span></li></ul>
+        <li>今回も参加者のみなさんの投票により<strong>飯王、LT王</strong>を決定します！</li>
+        <!-- TODO 飯王＆酒王のエントリー方法の案内をここに入れる -->
         <li>おいしいお酒、食べ物、LTの持ち込みをお待ちしております。
           <ul><li>ビールを飲める方はぜひプレモル戦線へご参加ください！</li></ul>
           <ul><li>(プレモル終了後の)後半戦のお酒をお待ちしております。</li></ul></li>
@@ -56,8 +52,8 @@
       <hr>
       <h3>開催日時</h3>
       <ul>
-        <li>2015年08月29日(土曜日)
-          <ul><li><a href="https://ja.wikipedia.org/wiki/%E7%84%BC%E8%82%89#.E5.85.A8.E5.9B.BD.E7.84.BC.E8.82.89.E5.8D.94.E4.BC.9A.E3.81.A8.E3.81.9D.E3.81.AE.E6.B4.BB.E5.8B.95"><strong>焼き肉</strong>(829)の日</a>です。</li>
+        <li>2016年05月29日(日曜日)
+          <ul><li>「Go! 肉の日」です。</li>
           </ul>
         </li>
       </ul>
@@ -84,193 +80,33 @@
       <h4>タグなど</h4>
       <ul>
         <li>公式タグ<ul>
-          <li><strong>tokyurubykaigi09</strong> (TokyuRuby会議09として)</li>
+          <li><strong>tokyurubykaigi10</strong> (TokyuRuby会議10として)</li>
         </ul></li>
         <li>Twitter のハッシュタグ<ul>
-          <li><strong><a href="http://twitter.com/search?q=%23tqrk09">#tqrk09</a></strong></li>
+          <li><strong><a href="http://twitter.com/search?q=%23tqrk10">#tqrk10</a></strong></li>
         </ul></li>
       </ul>
       <hr>
       <h3 id="schedule">スケジュール</h3>
       <p>(イベントの性質上、進行状況により時間が前後する場合がございます。ご了承下さい）</p>
-      <table class="fa-border">
-        <tr class="fa-border">
-          <th class="fa-border">13:30</th>
-          <td colspan="2">開場</td>
-        </tr>
-        <tr class="fa-border">
-          <th rowspan="16" class="fa-border">14:00 〜 15:50</th>
-          <td colspan="2">ライトニングトーク前半戦</td>
-        </tr>
-        <tr class="fa-border">
-          <td>三浦　美咲樹(Tokyu.rb)</td>
-          <td>進行と会場に関するご案内</td>
-        </tr>
-        <tr class="fa-border">
-          <td>ビールスポンサー　サントリー様</td>
-          <td>ザ・プレミアムモルツの美味しさの秘密</td>
-        </tr>
-        <tr class="fa-border">
-          <td>ビールスポンサー　サントリー様</td>
-          <td>キャンペーンのご説明</td>
-        </tr>
-        <tr class="fa-border">
-          <td>会場スポンサー　VOYAGE GROUP様</td>
-          <td>会場説明</td>
-        </tr>
-        <tr class="fa-border">
-          <td>@yucao24hours(スタッフ)</td>
-          <td>投票アプリ説明</td>
-        </tr>
-        <tr class="fa-border">
-          <td>mrkn</td>
-          <td>Rubyで機械学習</td>
-        </tr>
-        <tr class="fa-border">
-          <td>@yasulab</td>
-          <td>技術ドキュメントの翻訳を自動化することはできるのか?</td>
-        </tr>
-        <tr class="fa-border">
-          <td>上杉隆史</td>
-          <td>「Ruby On Railsで複数のcacheを使って若干パフォーマンスを上げる」</td>
-        </tr>
-        <tr class="fa-border">
-          <td>伊藤 浩一 (@koic)</td>
-          <td>JavaからRubyへの変遷を約10年見てきて、プロジェクトで変わったこと、変わっていないこと12集</td>
-        </tr>
-        <tr class="fa-border">
-          <td>takai</td>
-          <td>NetflixのmicroservicesスタックでRubyアプリケーションを動かしてみる</td>
-        </tr>
-        <tr class="fa-border">
-          <td>川村 徹 (@tkawa)</td>
-          <td>JSON APIについて（仮）</td>
-        </tr>
-        <tr class="fa-border">
-          <td>k0kubun</td>
-          <td>Rubyを使った開発環境構築の自動化</td>
-        </tr>
-        <tr class="fa-border">
-          <td>小林由憲</td>
-          <td>Rails と Instagram Ruby Gem を使って作る世界遺産検索サイト</td>
-        </tr>
-        <tr>
-          <td>rosylilly</td>
-          <td>Ruby によく似た言語、 Crystal のご提案</td>
-        </tr>
-        <tr class="fa-border">
-          <td>willnet</td>
-          <td>ビールビー活動報告</td>
-        </tr>
-        <tr class="fa-border">
-          <th class="fa-border">15:50 〜 16:45</th>
-          <td colspan="2">抽選LT抽選/休憩/抽選LT</td>
-        </tr>
-        <tr>
-          <th rowspan="16" class="fa-border">17:00 〜 18:45</th>
-          <td colspan="2">ライトニングトーク後半戦</td>
-        </tr>
-        <tr class="fa-border">
-          <td>Tシャツスポンサー Spice Life様</td>
-          <td>tmixと"(\( ⁰⊖⁰)/)"のこと</td>
-        </tr>
-        <tr class="fa-border">
-          <td>esaスポンサー  esa LLC様</td>
-          <td>(\( ⁰⊖⁰)/) のこと</td>
-        </tr>
-        <tr class="fa-border">
-          <td>馬場一樹(@kbaba1001)</td>
-          <td>Trailblazer<br />Railsのアーキテクチャを考える</td>
-        </tr>
-        <tr class="fa-border">
-          <td>いろ</td>
-          <td>オープンソースとアカデミアとコミュニティ原理主義</td>
-        </tr>
-        <tr>
-          <td>joker1007</td>
-          <td>口に出すと燃えそうな技術的なんたらについて酔っ払いが上から目線で話す5分間</td>
-        </tr>
-        <tr class="fa-border">
-          <td>dameninngenn</td>
-          <td>第一回 チキチキ 独断と偏見と狭い観測範囲の中から選ぶコミットログ選手権</td>
-        </tr>
-        <tr class="fa-border">
-          <td>@izumin5210</td>
-          <td>俺達の俺達による俺達のためのIoT</td>
-        </tr>
-        <tr class="fa-border">
-          <td>onk</td>
-          <td>bootstrap applications 〜bin/setup を使う世界〜</td>
-        </tr>
-        <tr class="fa-border">
-          <td>河野 朋子</td>
-          <td>Rails Madamがねこてちょうを作ったら</td>
-        </tr>
-        <tr>
-          <td>安田篤史</td>
-          <td>テーブル定義書の更新って再考の仕事ですよね！</td>
-        </tr>
-        <tr class="fa-border">
-          <td>fukayatsu</td>
-          <td>esaのなにか</td>
-        </tr>
-        <tr class="fa-border">
-          <td>yasaichi</td>
-          <td>Railsのエラーページ運用について本気出して考えてみた</td>
-        </tr>
-        <tr class="fa-border">
-          <td>小野寺類</td>
-          <td>RubyとMySQLを使ったアクセス分析基盤のリプレースに少しだけ関わったお話</td>
-        </tr>
-        <tr class="fa-border">
-          <td>平田 智子</td>
-          <td>「CoEdo.rbの紹介」</td>
-        </tr>
-        <tr>
-          <td>nekova</td>
-          <td>Elixir for Rubyist<br />(PhoenixとRailsの話もする予定です)</td>
-        </tr>
-        <tr class="fa-border"><th>18:45 〜 19:00</th>
-          <td colspan="2">基調講演投票・登壇者発表</td>
-        </tr>
-        <tr>
-          <th class="fa-border">19:00 〜 19:10</th>
-          <td colspan="2">基調講演[飯]</td>
-        </tr>
-        <tr class="fa-border">
-          <th class="fa-border">19:10 〜 19:20</th>
-          <td colspan="2">基調講演[LT]</td>
-        </tr>
-        <tr class="fa-border">
-          <th class="fa-border">19:20</th><td colspan="2">閉会の一本締め</td>
-        </tr>
-      </table>
       <hr>
-      <h3>前回の様子</h3>
-      <ul>
-        <li>写真:<ul>
-          <li><a href="https://www.flickr.com/photos/koichiroo/sets/72157649561418055/">https://www.flickr.com/photos/koichiroo/sets/72157649561418055/</a></li>
-        </ul></li>
-      </ul>
-      <hr>
+      <!-- TODO 前回の様子をここに入れる -->
       <h3>スタッフ</h3>
       <ul>
-        <li>実行委員長：三浦美咲樹</li>
-        <li>副委員長：櫻井達生</li>
-        <li>河野誠</li>
+        <li>実行委員長：加藤由佳</li>
+        <li>三浦美咲樹</li>
         <li>小川伸一郎</li>
-        <li>沢田正</li>
         <li>五十嵐邦明</li>
         <li>大場光一郎</li>
         <li>小椋隆史</li>
         <li>影山勝彦</li>
-        <li>加藤由佳</li>
         <li>三浦わか菜</li>
+        <li>沢田正</li>
       </ul>
       <hr>
     </div>
     <h3>お問い合わせ</h3>
-    <p class='contact'>TokyuRuby会議09に関するお問い合わせは、tokyurubykaigi_at_googlegroups.comまでメールにてご連絡ください。</p>
+    <p class='contact'>TokyuRuby会議10に関するお問い合わせは、tokyurubykaigi_at_googlegroups.comまでメールにてご連絡ください。</p>
   </div>
 
 </div>
@@ -282,4 +118,3 @@
 </div>
 </body>
 </html>
-


### PR DESCRIPTION
## 概要

Tokyu10 として告知を出せる (= 一般公開してok な) 状態をゴールにします。
- s/09/10/
- 日付を直す
- スタッフの顔ぶれが前回と違うので調整
- これから決める項目については、いったん記述から外す
