### PR TITLE
タイムテーブル公開＆一般募集開始

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     </div>
     <hr>
     <h3>参加登録</h3>
-    <div class="registration_external">一般参加登録の受付は5月上旬を予定しています。</div>
+    <div class="registration_external">一般参加登録は<a href="https://tokyu-rubykaigi.doorkeeper.jp/events/43995">こちら</a></div>
     <div class='event_desc'><hr>
       <h3>TokyuRuby会議について</h3>
       <ul>

--- a/index.html
+++ b/index.html
@@ -89,6 +89,160 @@
       <hr>
       <h3 id="schedule">スケジュール</h3>
       <p>(イベントの性質上、進行状況により時間が前後する場合がございます。ご了承下さい）</p>
+      <table class="fa-border">
+        <tr class="fa-border">
+          <th class="fa-border">13:30</th>
+          <td colspan="2">開場</td>
+        </tr>
+        <tr class="fa-border">
+          <th rowspan="16" class="fa-border">14:00 〜 15:50</th>
+          <td colspan="2">ライトニングトーク前半戦</td>
+        </tr>
+        <tr class="fa-border">
+          <td>加藤由佳 (Tokyu.rb)</td>
+          <td>進行と会場に関するご案内</td>
+        </tr>
+        <tr class="fa-border">
+          <td>ビールスポンサー　サントリー様</td>
+          <td>ザ・プレミアムモルツの美味しさの秘密</td>
+        </tr>
+        <tr class="fa-border">
+          <td>ビールスポンサー　サントリー様</td>
+          <td>キャンペーンのご説明</td>
+        </tr>
+        <tr class="fa-border">
+          <td>会場スポンサー　VOYAGE GROUP様</td>
+          <td>会場説明</td>
+        </tr>
+        <tr class="fa-border">
+          <td>@yucao24hours(スタッフ)</td>
+          <td>投票アプリ説明</td>
+        </tr>
+        <tr class="fa-border">
+          <td>joker1007</td>
+          <td>Rubykaigi drinkup日本酒スーパーバイザーによる5分で分かるやさしい日本酒</td>
+        </tr>
+        <tr class="fa-border">
+          <td>伊藤 浩一 (@koic)</td>
+          <td>RubyKaigiのDrinkupを支える技術</td>
+        </tr>
+        <tr class="fa-border">
+          <td>a_matsuda</td>
+          <td>RubyKaigiはなぜチケットが万単位で公用語が英語なのか？</td>
+        </tr>
+        <tr class="fa-border">
+          <td>Toshio Maki</td>
+          <td>メール製品を作って気づいたmailライブラリの光と闇について語る</td>
+        </tr>
+        <tr class="fa-border">
+          <td>菅原元気</td>
+          <td>pt-osc的何かとmigrationのすりあわせについて</td>
+        </tr>
+        <tr class="fa-border">
+          <td>コンユウスケ</td>
+          <td>RubyでルンバをHackせよ</td>
+        </tr>
+        <tr class="fa-border">
+          <td>大久保英樹 / oakbow</td>
+          <td>Rubyist のためのフィリピン留学</td>
+        </tr>
+        <tr class="fa-border">
+          <td>SHIOYA, Hiromu / @kwappa</td>
+          <td>オーバー・フォーティから始める高校生活</td>
+        </tr>
+        <tr>
+          <td>zunda</td>
+          <td>Railsの日付とか時刻オブジェクトたちはどこのタイムゾーンにいるでしょうか</td>
+        </tr>
+        <tr class="fa-border">
+          <td>ryopeko</td>
+          <td>Kaizen Platform で行っている Kaizen Week というイベントで継続的にサービスを改善しているお話</td>
+        </tr>
+        <tr class="fa-border">
+          <th class="fa-border">15:50 〜 16:45</th>
+          <td colspan="2">抽選LT抽選/休憩/抽選LT</td>
+        </tr>
+        <tr>
+          <th rowspan="16" class="fa-border">17:00 〜 18:45</th>
+          <td colspan="2">ライトニングトーク後半戦</td>
+        </tr>
+        <!-- スポンサー枠 -->
+        <tr class="fa-border">
+          <td>Tシャツスポンサー Spice Life様</td>
+          <td>(TBD)</td>
+        </tr>
+        <tr class="fa-border">
+          <td>esaスポンサー  esa LLC様</td>
+          <td>(TBD)</td>
+        </tr>
+
+        <tr class="fa-border">
+          <td>若杉 洋文</td>
+          <td>ruby-processing とか ruby-coreaudio できれば ActionCable と WebAudio も組み合わせて音響合成で遊べたらいいな</td>
+        </tr>
+        <tr class="fa-border">
+          <td>羽根田洋</td>
+          <td>またここで会おう、営業とエンジニアの距離を縮めて分かったこと</td>
+        </tr>
+        <tr>
+          <td>k0kubun</td>
+          <td>私がRails 5に入れたパッチとその背景</td>
+        </tr>
+        <tr class="fa-border">
+          <td>tdakak</td>
+          <td>オフィスのない会社で働いてみた</td>
+        </tr>
+        <tr class="fa-border">
+          <td>内山高広 (@highwide)</td>
+          <td>韻を踏むプログラムは書けるか</td>
+        </tr>
+        <tr class="fa-border">
+          <td>河野 誠(ginkouno)</td>
+          <td>Tokyu.rbとは何だったのか</td>
+        </tr>
+        <tr class="fa-border">
+          <td>野中哲</td>
+          <td>smsの送信・音声通話を発信するgemの紹介</td>
+        </tr>
+        <tr>
+          <td>安田篤史</td>
+          <td>苦いお酒が好きな人のためのコードの苦味の味わい方</td>
+        </tr>
+        <tr class="fa-border">
+          <td>みよひで</td>
+          <td>るびまを支えるRubyと人の力。そして未来のるびま（案）</td>
+        </tr>
+        <tr class="fa-border">
+          <td>川村 徹 (@tkawa)</td>
+          <td>Ruby Web Client (仮)</td>
+        </tr>
+        <tr class="fa-border">
+          <td>森 賢児 (morizyun)</td>
+          <td>英語で広がるRubyの世界</td>
+        </tr>
+        <tr class="fa-border">
+          <td>onk</td>
+          <td>これは使える！社内用 sinatra app 20 連発！</td>
+        </tr>
+        <tr>
+          <td>takiy33</td>
+          <td>最近コードレビューで困っていること(仮)</td>
+        </tr>
+        <tr class="fa-border"><th>18:45 〜 19:00</th>
+          <td colspan="2">基調講演投票・登壇者発表</td>
+        </tr>
+        <tr>
+          <th class="fa-border">19:00 〜 19:10</th>
+          <td colspan="2">基調講演[飯]</td>
+        </tr>
+        <tr class="fa-border">
+          <th class="fa-border">19:10 〜 19:20</th>
+          <td colspan="2">基調講演[LT]</td>
+        </tr>
+        <tr class="fa-border">
+          <th class="fa-border">19:20</th><td colspan="2">閉会の一本締め</td>
+        </tr>
+      </table>
       <hr>
       <!-- TODO 前回の様子をここに入れる -->
       <h3>スタッフ</h3>


### PR DESCRIPTION
## 概要
- [x] タイムテーブルを公開
- [x] 一般参加募集フォームへのリンクを設置
## 備考
- 時間割は前回 09 と同様 (発表数も同じ)
- LT 以外の発表枠の次第も前回同様 (サントリーさんの出番とか)
## 確認事項
- [ ] 前後半の間に入るスポンサー枠は2つで ok ? (spice life さんと esa さん)
